### PR TITLE
Fix avance1

### DIFF
--- a/lexer.py
+++ b/lexer.py
@@ -1,5 +1,4 @@
 import ply.lex as lex
-import ply.yacc as yacc
 
 reserved = {
     'Start' : 'START',
@@ -24,41 +23,55 @@ reserved = {
     'no': 'NOT'
 }
 
-tokens = ['SEMICOLON', 'COLON', 'COMMA', 'ASSIGN', 'LCURLYB', 'RCURLYB', 'LPAREN',
-    'RPAREN', 'LBRACKET', 'RBRACKET', 'PLUS', 'MINUS', 'DIVISION', 'TIMES','GTRTHAN', 
-    'GTREQLTHAN', 'LESSTHAN', 'LESSEQLTHAN', 'EQUALS', 'NOTEQUALS',
-    'INT_LITERAL', 'FLOAT_LITERAL', 'BOOL_LITERAL', 'STRING_LITERAL', 'ID'] + list(reserved.values())
+tokens = [
+    'REL_OP',
+    'ASSIGN_OP',
+    'ID',
+    'INT_LITERAL', 'FLOAT_LITERAL', 'BOOL_LITERAL', 'STRING_LITERAL']
+    
+tokens = tokens + list(reserved.values())
 
-t_SEMICOLON = r'\;'
-t_COLON = r'\:'
-t_COMMA = r'\,'
-t_ASSIGN = r'\='
-t_LCURLYB = r'\{'
-t_RCURLYB = r'\}'
-t_LPAREN = r'\('
-t_RPAREN = r'\)'
-t_LBRACKET = r'\['
-t_RBRACKET = r'\]'
-t_PLUS = r'\+'
-t_MINUS = r'\-'
-t_DIVISION = r'\/'
-t_TIMES = r'\*'
-t_GTRTHAN = r'\>'
-t_GTREQLTHAN = r'\>\='
-t_LESSTHAN = r'\<'
-t_LESSEQLTHAN = r'\<\='
-t_EQUALS = r'\=\='
-t_NOTEQUALS = r'\!\='
-t_INT_LITERAL = r'[0-9]+'
-t_FLOAT_LITERAL = r'[0-9]+(\. [0-9]+)'
-t_BOOL_LITERAL = r'(true) | (false)'
-t_STRING_LITERAL = r'\"(\w+|\s)+\"' # for word and space chars
+# Character literal tokens:
+# - COMMA, COLON, SEMICOLON,
+# - LEFT_PAREN, RIGHT_PAREN,
+# - LEFT_BRACKET, RIGHT_BRACKET,
+# - LEFT_CURLY, RIGHT_CURLY,
+# - PLUS, MINUS, TIMES, DIVIDE
+literals = [',', ':', ';',
+            '(', ')',
+            '[', ']',
+            '{', '}',
+            '+', '-', '*', '/']
+
+t_ASSIGN_OP = r'='
+t_REL_OP = r'<|<=|==|>|>=|!='
+
+# Ignore these chars (spaces and tabs)
 t_ignore  = ' \t'
+
+def t_BOOL_LITERAL(t):
+     r'(True)|(False)'
+     t.value = bool(t.value == 'True')
+     return t
 
 def t_ID(t):
      r'[a-zA-Z_][a-zA-Z_0-9]*'
      t.type = reserved.get(t.value,'ID')
      return t
+
+def t_STRING_LITERAL(t):
+    r'\"(\w|\s)+\"' # for word and space chars
+    return t
+
+def t_FLOAT_LITERAL(t):
+    r'[0-9]+\.[0-9]+'
+    t.value = float(t.value)
+    return t
+
+def t_INT_LITERAL(t):
+    r'[0-9]+'
+    t.value = int(t.value)
+    return t
 
 def t_newline(t):
     r'\n+'

--- a/lexer.py
+++ b/lexer.py
@@ -50,8 +50,8 @@ t_REL_OP = r'<|<=|==|>|>=|!='
 t_ignore  = ' \t'
 
 def t_BOOL_LITERAL(t):
-     r'(True)|(False)'
-     t.value = bool(t.value == 'True')
+     r'(true)|(false)'
+     t.value = bool(t.value == 'true')
      return t
 
 def t_ID(t):

--- a/parser.py
+++ b/parser.py
@@ -1,9 +1,9 @@
-from lexer import Lexer, tokens
+from lexer import Lexer, tokens, literals
 
 import ply.yacc as yacc
 
 def p_game(p):
-    '''game : GAME ID SEMICOLON game_vars game_funcs game_start game_update'''
+    '''game : GAME ID ';' game_vars game_funcs'''
     p[0] = "Aceptado"
 
 def p_game_vars(p):
@@ -11,91 +11,49 @@ def p_game_vars(p):
                  | empty'''
 
 def p_game_funcs(p):
-    '''game_funcs : declare_func game_funcs
-                  | empty'''
+    '''game_funcs : declare_func game_funcs 
+                  | game_start'''
 
 def p_game_start(p):
-    '''game_start : func_start
-                  | empty'''
+    '''game_start : func_start game_update
+                  | game_update'''
 
 def p_game_update(p):
     '''game_update : func_update 
                    | empty'''
 
 def p_block_vars(p):
-    '''block_vars : DECLARE LCURLYB RCURLYB
-                  | DECLARE LCURLYB declare_var declare_var_prima RCURLYB'''
-
-def p_declare_var(p):
-    '''declare_var : type ID SEMICOLON
-                   | type list_vars SEMICOLON'''
+    '''block_vars : DECLARE '{' declare_vars '}' '''
     
 def p_declare_var_prima(p):
-    '''declare_var_prima : declare_var declare_var_prima
-                         | empty'''
+    '''declare_vars : declare_var declare_vars
+                    | empty'''
+
+def p_declare_var(p):
+    '''declare_var : type list_vars ';' '''
 
 def p_list_vars(p):
-    '''list_vars : LBRACKET ID list_vars_prima RBRACKET '''
+    '''list_vars : ID list_vars_prima'''
 
 def p_list_vars_prima(p):
-    '''list_vars_prima : COMMA ID list_vars_prima
+    '''list_vars_prima : ',' ID list_vars_prima
                        | empty'''
-
-def p_statement(p):
-    '''statement : call_func SEMICOLON
-                 | for_loop
-                 | while_loop
-                 | conditional
-                 | assignment SEMICOLON'''
-
-def p_statement_prima(p):
-    '''statement_prima : statement statement_prima
-                       | empty'''
-
-def p_call_func(p):
-    '''call_func : ID LPAREN list_args RPAREN
-                 | ID LPAREN RPAREN'''
-
-def p_list_args(p):
-    '''list_args : god_exp list_args_prima'''
-
-def p_list_args_prima(p):
-    '''list_args_prima : COMMA god_exp list_args_prima
-                       | empty'''
-
-def p_for_loop(p):
-    '''for_loop : FOR LPAREN assignment RPAREN SEMICOLON god_exp SEMICOLON assignment RPAREN LCURLYB block_code RCURLYB'''
-
-def p_while_loop(p):
-    '''while_loop : WHILE LPAREN god_exp RPAREN LCURLYB block_code RCURLYB'''
-
-def p_conditional(p):
-    '''conditional : IF LPAREN god_exp RPAREN LCURLYB block_code RCURLYB
-                   | IF LPAREN god_exp RPAREN LCURLYB block_code RCURLYB ELSE conditional_prima LCURLYB block_code RCURLYB'''
-
-def p_conditional_prima(p):
-    '''conditional_prima : conditional
-                        | empty'''
-
-def p_assignment(p):
-    '''assignment : id_exp ASSIGN god_exp'''
 
 def p_declare_func(p):
-    '''declare_func : FUNC ID COLON func_type declare_func_params declare_func_code'''
+    '''declare_func : FUNC ID ':' func_type '(' list_params ')' '{' block_code '}' '''
 
-def p_declare_func_params(p):
-    '''declare_func_params : LPAREN RPAREN
-                           | LPAREN list_params RPAREN'''
+def p_func_start(p):
+    '''func_start : FUNC START ':' VOID '(' ')' '{' block_code '}' '''
 
-def p_declare_func_code(p):
-    '''declare_func_code : LCURLYB RCURLYB
-                         | LCURLYB block_code RCURLYB'''
+def p_func_update(p):
+    '''func_update : FUNC UPDATE ':' VOID '(' ')' '{' block_code '}' '''
 
 def p_list_params(p):
-    '''list_params : type ID list_params_prima'''
+    '''list_params : type ID list_params_prima
+                   | empty'''
 
 def p_list_params_prima(p):
-    '''list_params_prima : COMMA type ID list_params_prima
+    '''list_params_prima : ',' type ID list_params_prima
                          | empty'''
 
 def p_func_type(p):
@@ -103,41 +61,65 @@ def p_func_type(p):
                  | VOID '''
 
 def p_block_code(p):
-    '''block_code : block_vars statement statement_prima
-                  | statement statement_prima'''
+    '''block_code : block_vars statement_prima
+                  | statement statement_prima
+                  | empty'''
 
-def p_func_start(p):
-    '''func_start : FUNC START COLON VOID LPAREN RPAREN LCURLYB RCURLYB
-                  | FUNC START COLON VOID LPAREN RPAREN LCURLYB block_code RCURLYB'''
+def p_statement(p):
+    '''statement : call_func ';'
+                 | for_loop
+                 | while_loop
+                 | conditional
+                 | assignment ';' '''
 
-def p_func_update(p):
-    '''func_update : FUNC UPDATE COLON VOID LPAREN RPAREN LCURLYB RCURLYB
-                   | FUNC UPDATE COLON VOID LPAREN RPAREN LCURLYB block_code RCURLYB'''
+def p_statement_prima(p):
+    '''statement_prima : statement statement_prima
+                       | empty'''
+
+def p_call_func(p):
+    '''call_func : ID '(' list_args ')' '''
+
+def p_list_args(p):
+    '''list_args : god_exp list_args_prima
+                 | empty'''
+
+def p_list_args_prima(p):
+    '''list_args_prima : ',' god_exp list_args_prima
+                       | empty'''
+
+def p_for_loop(p):
+    '''for_loop : FOR '(' assignment ';' god_exp ';' assignment ')' '{' block_code '}' '''
+
+def p_while_loop(p):
+    '''while_loop : WHILE '(' god_exp ')' '{' block_code '}' '''
+
+def p_conditional(p):
+    '''conditional : IF '(' god_exp ')' '{' block_code '}' conditional_prima'''
+
+def p_conditional_prima(p):
+    '''conditional_prima : ELSE conditional
+                         | ELSE '{' block_code '}' 
+                         | empty'''
+
+def p_assignment(p):
+    '''assignment : id_exp ASSIGN_OP god_exp'''
 
 def p_type(p):
-    '''type : INT type_prima
-            | FLOAT type_prima
-            | BOOLEAN type_prima
-            | CHAR type_prima
-            | SPRITE type_prima'''
+    '''type : INT type_dims
+            | FLOAT type_dims
+            | BOOLEAN type_dims
+            | CHAR type_dims
+            | SPRITE type_dims'''
 
-def p_type_prima(p):
-    '''type_prima : LBRACKET INT_LITERAL RBRACKET
-                  | LBRACKET INT_LITERAL COMMA INT_LITERAL RBRACKET
-                  | empty'''
+def p_type_dims(p):
+    '''type_dims : '[' INT_LITERAL ']'
+                 | '[' INT_LITERAL ',' INT_LITERAL ']'
+                 | empty'''
 
 # Pending to add unary logic operator NOT
 def p_logicop(p):
     '''logicop : AND
                | OR'''
-
-def p_relop(p):
-    '''relop : GTRTHAN
-             | GTREQLTHAN
-             | LESSTHAN
-             | LESSEQLTHAN
-             | EQUALS
-             | NOTEQUALS'''
 
 def p_god_exp(p):
     '''god_exp : super_exp god_exp_prima'''
@@ -150,27 +132,27 @@ def p_super_exp(p):
     '''super_exp : exp super_exp_prima'''
 
 def p_super_exp_prima(p):
-    '''super_exp_prima : relop super_exp
+    '''super_exp_prima : REL_OP super_exp
                        | empty'''
 
 def p_exp(p):
     '''exp : term exp_prima'''
 
 def p_exp_prima(p):
-    '''exp_prima : PLUS term
-                  | MINUS term
-                  | empty'''
+    '''exp_prima : '+' exp
+                 | '-' exp
+                 | empty'''
 
 def p_term(p):
     '''term : fact term_prima'''
 
 def p_term_prima(p):
-    '''term_prima : DIVISION term
-                  | TIMES term
+    '''term_prima : '/' term
+                  | '*' term
                   | empty'''
 
 def p_fact(p):
-    '''fact : LPAREN god_exp RPAREN
+    '''fact : '(' god_exp ')'
             | id_exp
             | INT_LITERAL
             | FLOAT_LITERAL
@@ -179,10 +161,10 @@ def p_fact(p):
 
 def p_id_exp(p):
     '''id_exp : ID
-              | ID LBRACKET god_exp RBRACKET
-              | ID LBRACKET god_exp COMMA god_exp RBRACKET'''
+              | ID '[' god_exp ']'
+              | ID '[' god_exp ',' god_exp ']' '''
 
-def p_empty(t): # representa epsilon
+def p_empty(p): # representa epsilon
     '''empty : '''
     pass
 
@@ -191,8 +173,8 @@ def p_error(p):
 
 parser = yacc.yacc(debug=True)
 
-file_name = input("Nombre de archivo: ")
-f = open(file_name, 'r')
+# file_name = input("Nombre de archivo: ")
+f = open('test.tudi', 'r')
 data = f.read()
 f.close()
 

--- a/parser.py
+++ b/parser.py
@@ -25,7 +25,7 @@ def p_game_update(p):
 def p_block_vars(p):
     '''block_vars : DECLARE '{' declare_vars '}' '''
     
-def p_declare_var_prima(p):
+def p_declare_vars(p):
     '''declare_vars : declare_var declare_vars
                     | empty'''
 

--- a/test.tudi
+++ b/test.tudi
@@ -2,13 +2,88 @@ game test;
 
 declare {
     int x;
+    float a, b, c;
+    bool cond;
+    char _char_;
+    sprite player;
+    int[5] vector;
+    bool[5,5] matrix;
 }
 
-func DoSomethingA : int () {
+func DoSomethingA : int () {}
+
+func DoSomethingB : sprite[1,1] (int pos_x, int pos_y) {
+    declare {
+        int up;
+    }
+}
+
+func DoSomethingC : void (bool cond) {
+    declare {
+        int up;
+    }
+    
+    cond = false;
 }
 
 func Start : void () {
+    x = 1;
+    a = 0.1;
+    b = 1.0;
+    cond = false;
+    vector[1] = 5;
+    matrix[1+1 / 2 ,1 - 1] = true;
 }
 
 func Update : void () {
+    declare {
+        int up;
+    }
+
+    up = DoSomethingB() + 1 - x * vector[1] / (matrix[1,1] > 2 y b < 0.2);
+
+    for (x = 1; x < 9; x = x + 1) {
+        if (x == 2 o x == 3) {
+            DoSomethingC(false);
+        }
+    }
+
+    x = 1;
+    while (x < 3 y x > 0) {
+        x = x + 1;
+        if (matrix[1,1] == false) {
+        cond = true;
+        } else {
+            cond = false;
+        }
+    }
+
+    if (matrix[1,1] == false) {
+        cond = true;
+    }
+
+    if (matrix[1,1] == false) {
+        cond = true;
+    } else {
+        cond = false;
+    }
+
+    if (matrix[1,1] == false) {
+        cond = true;
+    } else if (vector[0] != 2) {
+        cond = false;
+    }
+
+    if (matrix[1,1] == false) {
+        cond = true;
+        if (matrix[1,1] == false) {
+            cond = true;
+        } else {
+            cond = false;
+        }
+    } else if (vector[0] != 2) {
+        cond = false;
+    } else if (vector[0] != 2) {
+        cond = false;
+    } 
 }


### PR DESCRIPTION
## Cambios en Lexer
- Se remueve un import.
- Se reduce el número de expresiones regulares; se agrupan unas y otras se cambian a literals.
- `t_BOOL_LITERAL` se pone primero que `t_ID` y `t_FLOAT_LITERAL` se pone primero que `t_INT_LITERAL`. Se reordena de esta manera para resolver conflictos en los que no se detectaban los valores booleanos (`true` y `false`) como palabras reservadas, y en los que la primera parte del float se tomaba como int.

## Cambios en Parser
- Los tokens de un carácter se sustituyen con su literal.
- Se cambian las reglas `game` para resolver conflictos de shift/reduce.
- A la regla de lista de variables `list_vars` se le quitan los brackets (`[ ]`) para evitar la ambigüedad que generaba shift/reduce conflicts.
- Se arregla un error en el `for loop`.
- Se arregla un error en `exp_prima` en el que generaba `term` en lugar de `exp`.
- El estatuto condicional `conditional` no funcionaba (solamente con un solo IF), se arregla para hacerlo funcionar.
- Se simplifican algunas reglas.

## Otros
- Se vuelve más robusto el archivo test.