### PR TITLE
Refactor quads: Move quadruples to their own file

### DIFF
--- a/parser_tudi.py
+++ b/parser_tudi.py
@@ -5,8 +5,6 @@ from sem_cube import SemanticCube
 
 import ply.yacc as yacc
 
-tokens = LexerTudi.tokens
-literals = LexerTudi.literals
 
 class Quadruple():
     def __init__(self, operator, left_operand, right_operand, temp):
@@ -58,348 +56,352 @@ def check_stack_operand(arr_operands):
         result_t = type_dict[result_t]
         type_stack.append(result_t)
 
-def p_game(p):
-    '''game : GAME ID ';' CANVAS ASSIGN_OP INT_LITERAL ',' INT_LITERAL ';' game_vars game_funcs'''
-    p[0] = "Aceptado"
-    print("Todo valido")
+class ParserTudi(object):
 
-    global func_dir
-    for func, func_items in func_dir.directory.items():
-        print('Scope:', func)
-        for func_item, values in func_items.items():
-            if func_item == 'table':
-                print('\t- Variables:')
-                for k, v  in values.table.items():
-                    print('\t---', k, v)
-            else:
-                print('\t-', func_item, ':', values)
-        print()
-    for i in quadruples:
-        print(i)
+    tokens = LexerTudi.tokens
+    literals = LexerTudi.literals
 
-def p_game_vars(p):
-    '''game_vars : block_vars
-                 | empty'''
+    def p_game(self, p):
+        '''game : GAME ID ';' CANVAS ASSIGN_OP INT_LITERAL ',' INT_LITERAL ';' game_vars game_funcs'''
+        p[0] = "Aceptado"
+        print("Todo valido")
 
-def p_game_funcs(p):
-    '''game_funcs : declare_func game_funcs 
-                  | game_start'''
+        global func_dir
+        for func, func_items in func_dir.directory.items():
+            print('Scope:', func)
+            for func_item, values in func_items.items():
+                if func_item == 'table':
+                    print('\t- Variables:')
+                    for k, v  in values.table.items():
+                        print('\t---', k, v)
+                else:
+                    print('\t-', func_item, ':', values)
+            print()
+        for i in quadruples:
+            print(i)
 
-def p_game_start(p):
-    '''game_start : func_start game_update
-                  | game_update'''
-
-def p_game_update(p):
-    '''game_update : func_update 
-                   | empty'''
-
-def p_block_vars(p):
-    '''block_vars : DECLARE '{' declare_vars '}' '''
-
-def p_declare_vars(p):
-    '''declare_vars : declare_var declare_vars
+    def p_game_vars(self, p):
+        '''game_vars : block_vars
                     | empty'''
 
-def p_declare_var(p):
-    '''declare_var : type list_vars ';' '''
-    global last_vars
-    last_vars['var_type'] = p[1]
-    
-    for var_id in p[2]:
-        if not func_dir.add_variable(last_vars['scope'], var_id.value, last_vars['var_type']):
-            print(f'Error: Re-declaration of variable \'{var_id.value}\' at line: {var_id.lineno}')
-            exit()
+    def p_game_funcs(self, p):
+        '''game_funcs : declare_func game_funcs
+                    | game_start'''
 
-def p_list_vars(p):
-    '''list_vars : ID list_vars_prima'''
-    p[0] = [Token(p[1], p.lineno(1))] + p[2]
+    def p_game_start(self, p):
+        '''game_start : func_start game_update
+                    | game_update'''
 
-def p_list_vars_prima(p):
-    '''list_vars_prima : ',' ID list_vars_prima
-                       | empty'''
-    if len(p) > 2:
-        p[0] = [Token(p[2], p.lineno(2))] + p[3]
-    else:
-        p[0] = []
+    def p_game_update(self, p):
+        '''game_update : func_update
+                    | empty'''
 
-def p_declare_func(p):
-    '''declare_func : FUNC ID ':' func_type seen_dec_func '(' list_params ')' '{' block_code '}' '''
+    def p_block_vars(self, p):
+        '''block_vars : DECLARE '{' declare_vars '}' '''
 
-def p_func_start(p):
-    '''func_start : FUNC START ':' VOID seen_dec_func '(' ')' '{' block_code '}' '''
+    def p_declare_vars(self, p):
+        '''declare_vars : declare_var declare_vars
+                        | empty'''
 
-def p_func_update(p):
-    '''func_update : FUNC UPDATE ':' VOID seen_dec_func '(' ')' '{' block_code '}' '''
+    def p_declare_var(self, p):
+        '''declare_var : type list_vars ';' '''
+        global last_vars
+        last_vars['var_type'] = p[1]
 
-def p_list_params(p):
-    '''list_params : type ID seen_param list_params_prima
-                   | empty'''
+        for var_id in p[2]:
+            if not func_dir.add_variable(last_vars['scope'], var_id.value, last_vars['var_type']):
+                print(f'Error: Re-declaration of variable \'{var_id.value}\' at line: {var_id.lineno}')
+                exit()
 
-def p_list_params_prima(p):
-    '''list_params_prima : ',' type ID seen_param list_params_prima
-                         | empty'''
+    def p_list_vars(self, p):
+        '''list_vars : ID list_vars_prima'''
+        p[0] = [Token(p[1], p.lineno(1))] + p[2]
 
-def p_func_type(p):
-    '''func_type : type
-                 | VOID '''
-    p[0] = p[1]
+    def p_list_vars_prima(self, p):
+        '''list_vars_prima : ',' ID list_vars_prima
+                        | empty'''
+        if len(p) > 2:
+            p[0] = [Token(p[2], p.lineno(2))] + p[3]
+        else:
+            p[0] = []
 
-def p_block_code(p):
-    '''block_code : block_vars statement_prima
-                  | statement statement_prima
-                  | empty'''
+    def p_declare_func(self, p):
+        '''declare_func : FUNC ID ':' func_type seen_dec_func '(' list_params ')' '{' block_code '}' '''
 
-def p_statement(p):
-    '''statement : call_func ';'
-                 | for_loop
-                 | while_loop
-                 | conditional
-                 | assignment ';' 
-                 | return ';' 
-                 | call_method ';' '''
+    def p_func_start(self, p):
+        '''func_start : FUNC START ':' VOID seen_dec_func '(' ')' '{' block_code '}' '''
 
-def p_statement_prima(p):
-    '''statement_prima : statement statement_prima
-                       | empty'''
+    def p_func_update(self, p):
+        '''func_update : FUNC UPDATE ':' VOID seen_dec_func '(' ')' '{' block_code '}' '''
 
-def p_return(p):
-    '''return : RETURN god_exp'''
+    def p_list_params(self, p):
+        '''list_params : type ID seen_param list_params_prima
+                    | empty'''
 
-def p_io_func(p):
-    '''io_func : PRINT '(' io_func_prima ')' 
-               | READ  '(' io_func_prima ')' '''
+    def p_list_params_prima(self, p):
+        '''list_params_prima : ',' type ID seen_param list_params_prima
+                            | empty'''
 
-def p_io_func_prima(p):
-    '''io_func_prima : STRING_LITERAL
-                     | empty'''
-
-def p_cast_func(p):
-    '''cast_func : INT cast_func_prima 
-                 | FLOAT cast_func_prima
-                 | BOOLEAN cast_func_prima'''
-
-def p_cast_func_prima(p):
-    '''cast_func_prima : '(' STRING_LITERAL ')'
-                       | '(' god_exp ')' '''
-
-def p_call_func(p):
-    '''call_func : ID '(' list_args ')'
-                 | io_func 
-                 | cast_func'''
-    if len(p) > 2:
-        if not func_dir.find_function(p[1]):
-            print(f'Error: Function \'{p[1]}\' at line {p.lineno(1)} was not declared.')
-            exit()
-    p[0] = [0, 'B', p[0]] # Dummy value in the meantime, need help obtaining data type
-
-def p_call_method(p):
-    '''call_method : id_exp '.' call_method_prima '(' list_args ')' '''
-
-def p_call_method_prima(p):
-    '''call_method_prima : SETPOSITION
-                         | TRANSLATE
-                         | SETCONTROLLABLE '''
-
-def p_list_args(p):
-    '''list_args : god_exp list_args_prima
-                 | empty'''
-
-def p_list_args_prima(p):
-    '''list_args_prima : ',' god_exp list_args_prima
-                       | empty'''
-
-def p_for_loop(p):
-    '''for_loop : FOR '(' assignment ';' god_exp ';' assignment ')' '{' block_code '}' '''
-
-def p_while_loop(p):
-    '''while_loop : WHILE while_act_1 '(' god_exp ')' '{' block_code '}' '''
-
-def p_while_act_1(p):
-    '''while_act_1 : '''
-    goto_stack.append(len(quadruples))
-
-def p_conditional(p):
-    '''conditional : IF '(' god_exp ')' '{' block_code '}' conditional_prima'''
-
-def p_conditional_prima(p):
-    '''conditional_prima : ELSE conditional
-                         | ELSE '{' block_code '}' 
-                         | empty'''
-
-def p_assignment(p):
-    '''assignment : id_exp ASSIGN_OP god_exp'''
-
-def p_type(p):
-    '''type : INT type_dims
-            | FLOAT type_dims
-            | BOOLEAN type_dims
-            | CHAR type_dims
-            | SPRITE type_dims'''
-    if p[2] is not None:
-        p[0] = "-".join([p[1], p[2]])
-    else:
+    def p_func_type(self, p):
+        '''func_type : type
+                    | VOID '''
         p[0] = p[1]
 
-def p_type_dims(p):
-    '''type_dims : '[' INT_LITERAL ']'
-                 | '[' INT_LITERAL ',' INT_LITERAL ']'
-                 | empty'''
-    if len(p) == 6:
-        p[0] = 'arr2d'
-    elif len(p) == 4:
-        p[0] = 'arr1d'
+    def p_block_code(self, p):
+        '''block_code : block_vars statement_prima
+                    | statement statement_prima
+                    | empty'''
+
+    def p_statement(self, p):
+        '''statement : call_func ';'
+                    | for_loop
+                    | while_loop
+                    | conditional
+                    | assignment ';'
+                    | return ';'
+                    | call_method ';' '''
+
+    def p_statement_prima(self, p):
+        '''statement_prima : statement statement_prima
+                        | empty'''
+
+    def p_return(self, p):
+        '''return : RETURN god_exp'''
+
+    def p_io_func(self, p):
+        '''io_func : PRINT '(' io_func_prima ')'
+                | READ  '(' io_func_prima ')' '''
+
+    def p_io_func_prima(self, p):
+        '''io_func_prima : STRING_LITERAL
+                        | empty'''
+
+    def p_cast_func(self, p):
+        '''cast_func : INT cast_func_prima
+                    | FLOAT cast_func_prima
+                    | BOOLEAN cast_func_prima'''
+
+    def p_cast_func_prima(self, p):
+        '''cast_func_prima : '(' STRING_LITERAL ')'
+                        | '(' god_exp ')' '''
+
+    def p_call_func(self, p):
+        '''call_func : ID '(' list_args ')'
+                    | io_func
+                    | cast_func'''
+        if len(p) > 2:
+            if not func_dir.find_function(p[1]):
+                print(f'Error: Function \'{p[1]}\' at line {p.lineno(1)} was not declared.')
+                exit()
+        p[0] = [0, 'B', p[0]] # Dummy value in the meantime, need help obtaining data type
+
+    def p_call_method(self, p):
+        '''call_method : id_exp '.' call_method_prima '(' list_args ')' '''
+
+    def p_call_method_prima(self, p):
+        '''call_method_prima : SETPOSITION
+                            | TRANSLATE
+                            | SETCONTROLLABLE '''
+
+    def p_list_args(self, p):
+        '''list_args : god_exp list_args_prima
+                    | empty'''
+
+    def p_list_args_prima(self, p):
+        '''list_args_prima : ',' god_exp list_args_prima
+                        | empty'''
+
+    def p_for_loop(self, p):
+        '''for_loop : FOR '(' assignment ';' god_exp ';' assignment ')' '{' block_code '}' '''
+
+    def p_while_loop(self, p):
+        '''while_loop : WHILE while_act_1 '(' god_exp ')' '{' block_code '}' '''
+
+    def p_while_act_1(self, p):
+        '''while_act_1 : '''
+        goto_stack.append(len(quadruples))
+
+    def p_conditional(self, p):
+        '''conditional : IF '(' god_exp ')' '{' block_code '}' conditional_prima'''
+
+    def p_conditional_prima(self, p):
+        '''conditional_prima : ELSE conditional
+                            | ELSE '{' block_code '}'
+                            | empty'''
+
+    def p_assignment(self, p):
+        '''assignment : id_exp ASSIGN_OP god_exp'''
+
+    def p_type(self, p):
+        '''type : INT type_dims
+                | FLOAT type_dims
+                | BOOLEAN type_dims
+                | CHAR type_dims
+                | SPRITE type_dims'''
+        if p[2] is not None:
+            p[0] = "-".join([p[1], p[2]])
+        else:
+            p[0] = p[1]
+
+    def p_type_dims(self, p):
+        '''type_dims : '[' INT_LITERAL ']'
+                    | '[' INT_LITERAL ',' INT_LITERAL ']'
+                    | empty'''
+        if len(p) == 6:
+            p[0] = 'arr2d'
+        elif len(p) == 4:
+            p[0] = 'arr1d'
 
 
-def p_god_exp(p):
-    '''god_exp : super_exp god_exp_neuro_1 god_exp_prima'''
+    def p_god_exp(self, p):
+        '''god_exp : super_exp god_exp_neuro_1 god_exp_prima'''
 
-def p_god_exp_neuro_1(p):
-    '''god_exp_neuro_1 : '''
-    check_stack_operand(arr_logicops)
+    def p_god_exp_neuro_1(self, p):
+        '''god_exp_neuro_1 : '''
+        check_stack_operand(arr_logicops)
 
-def p_god_exp_prima(p):
-    '''god_exp_prima : LOGIC_OPS add_op god_exp
-                     | empty'''
+    def p_god_exp_prima(self, p):
+        '''god_exp_prima : LOGIC_OPS add_op god_exp
+                        | empty'''
 
-def p_super_exp(p):
-    '''super_exp : exp super_exp_neuro_1 super_exp_prima'''
+    def p_super_exp(self, p):
+        '''super_exp : exp super_exp_neuro_1 super_exp_prima'''
 
-def p_super_exp_neuro_1(p):
-    '''super_exp_neuro_1 : '''
-    check_stack_operand(arr_relops)
+    def p_super_exp_neuro_1(self, p):
+        '''super_exp_neuro_1 : '''
+        check_stack_operand(arr_relops)
 
-def p_super_exp_prima(p):
-    '''super_exp_prima : REL_OPS add_op exp
-                       | empty'''
+    def p_super_exp_prima(self, p):
+        '''super_exp_prima : REL_OPS add_op exp
+                        | empty'''
 
-def p_exp(p):
-    '''exp : term exp_neuro_1 exp_prima'''
+    def p_exp(self, p):
+        '''exp : term exp_neuro_1 exp_prima'''
 
-def p_exp_neuro_1(p):
-    '''exp_neuro_1 : '''
-    check_stack_operand(["+", "-"])
+    def p_exp_neuro_1(self, p):
+        '''exp_neuro_1 : '''
+        check_stack_operand(["+", "-"])
 
-def p_exp_prima(p):
-    '''exp_prima : '+' add_op exp
-                 | '-' add_op exp
-                 | empty'''
+    def p_exp_prima(self, p):
+        '''exp_prima : '+' add_op exp
+                    | '-' add_op exp
+                    | empty'''
 
-def p_term(p):
-    '''term : fact term_neuro_1 term_prima'''
+    def p_term(self, p):
+        '''term : fact term_neuro_1 term_prima'''
 
-def p_term_neuro_1(p):
-    '''term_neuro_1 : '''
-    check_stack_operand(["*", "/"])
+    def p_term_neuro_1(self, p):
+        '''term_neuro_1 : '''
+        check_stack_operand(["*", "/"])
 
-def p_term_prima(p):
-    '''term_prima : '/' add_op term
-                  | '*' add_op term
-                  | empty'''
+    def p_term_prima(self, p):
+        '''term_prima : '/' add_op term
+                    | '*' add_op term
+                    | empty'''
 
-def p_fact(p):
-    '''fact : fact_neuro_1 '(' god_exp ')' fact_neuro_2
-            | fact_constants '''
+    def p_fact(self, p):
+        '''fact : fact_neuro_1 '(' god_exp ')' fact_neuro_2
+                | fact_constants '''
 
-    if len(p) == 2:
-        operand_stack.append(p[1][0]) # aiuda
-        type_stack.append(p[1][1]) # aiuda
-    p[0] = p[1]
+        if len(p) == 2:
+            operand_stack.append(p[1][0]) # aiuda
+            type_stack.append(p[1][1]) # aiuda
+        p[0] = p[1]
 
 
-def p_fact_constants(p):
-    '''
-    fact_constants : id_exp
-                    | int
-                    | float
-                    | bool
-                    | call_func
-    '''
-    p[0] = p[1]
+    def p_fact_constants(self, p):
+        '''
+        fact_constants : id_exp
+                        | int
+                        | float
+                        | bool
+                        | call_func
+        '''
+        p[0] = p[1]
 
-def p_int(p):
-    '''int : INT_LITERAL'''
-    p[0] = [p[1], 'I'] # Dummy value on the meantime
+    def p_int(self, p):
+        '''int : INT_LITERAL'''
+        p[0] = [p[1], 'I'] # Dummy value on the meantime
 
-def p_float(p):
-    '''float : FLOAT_LITERAL'''
-    p[0] = [p[1], 'F'] # Dummy value on the meantime
+    def p_float(self, p):
+        '''float : FLOAT_LITERAL'''
+        p[0] = [p[1], 'F'] # Dummy value on the meantime
 
-def p_bool(p):
-    '''bool : BOOL_LITERAL'''
-    p[0] = [p[1], 'B'] # Dummy value on the meantime
+    def p_bool(self, p):
+        '''bool : BOOL_LITERAL'''
+        p[0] = [p[1], 'B'] # Dummy value on the meantime
 
-def p_add_op(p):
-    '''add_op : '''
-    operator_stack.append(p[-1]) # Add previous operator to stack
+    def p_add_op(self, p):
+        '''add_op : '''
+        operator_stack.append(p[-1]) # Add previous operator to stack
 
-def p_fact_neuro_1(p):
-    '''fact_neuro_1 :'''
-    operator_stack.append("|") # Fondo falso
+    def p_fact_neuro_1(self, p):
+        '''fact_neuro_1 :'''
+        operator_stack.append("|") # Fondo falso
 
-def p_fact_neuro_2(p):
-    '''fact_neuro_2 :'''
-    operator_stack.pop() # Fin del fondo falso
+    def p_fact_neuro_2(self, p):
+        '''fact_neuro_2 :'''
+        operator_stack.pop() # Fin del fondo falso
 
-def p_id_exp(p):
-    '''id_exp : id_term
-              | id_term '[' god_exp ']'
-              | id_term '[' god_exp ',' god_exp ']' '''
-    if len(p) == 6:
-        p[0] = Token([p[1][0], p[3], p[5]], p.lineno(1))
-    elif len(p) == 4:
-        p[0] = Token([p[1][0], p[3]], p.lineno(1))
-    else:
-        p[0] = Token(p[1][0], p.lineno(1))
+    def p_id_exp(self, p):
+        '''id_exp : id_term
+                | id_term '[' god_exp ']'
+                | id_term '[' god_exp ',' god_exp ']' '''
+        if len(p) == 6:
+            p[0] = Token([p[1][0], p[3], p[5]], p.lineno(1))
+        elif len(p) == 4:
+            p[0] = Token([p[1][0], p[3]], p.lineno(1))
+        else:
+            p[0] = Token(p[1][0], p.lineno(1))
 
-    if not func_dir.find_variable(last_vars['scope'], p[1][0]):
-        print(f'Error: Variable \'{p[1]}\' at line {p.lineno(1)} was not declared.')
+        if not func_dir.find_variable(last_vars['scope'], p[1][0]):
+            print(f'Error: Variable \'{p[1]}\' at line {p.lineno(1)} was not declared.')
+            exit()
+        p[0] = [0, p[1][1], p[0]]
+
+    def p_id_term(self, p):
+        '''id_term : ID'''
+        p[0] = [p[1], 'B'] # need help obtaining the type of the variable
+
+    def p_seen_dec_func(self, p):
+        '''seen_dec_func :'''
+        # Al llegar a esta regla, significa que hemos visto el inicio de
+        # la declaración de una función.
+        # p[-1] es la producción en la que aparece el tipo de retorno
+        # p[-3] es la producción en la que aparece el nombre de la función
+        global last_vars
+        last_vars['scope'] = p[-3]
+        if not func_dir.add_function(last_vars['scope'], p[-1]):
+            print(f'Error: Re-declaration of function \'{p[-3]}\'.')
+            exit()
+
+    def p_seen_param(self, p):
+        '''seen_param :'''
+        # Al llegar a esta regla, significa que hemos visto
+        # la declaración de un parámetro.
+        # p[-1] es la producción en la que aparece nombre del parámetro
+        # p[-2] es la producción en la que aparece el tipo de dato
+        if not func_dir.add_param(last_vars['scope'], p[-1], p[-2]):
+            print(f'Error: Re-declaration of function parameter \'{p[-1]}\'.')
+            exit()
+
+    def p_empty(self, p): # representa epsilon
+        '''empty : '''
+        pass
+
+    def p_error(self, p):
+        print("Syntax error in input at line: ", p, p.lineno)
         exit()
-    p[0] = [0, p[1][1], p[0]]
 
-def p_id_term(p):
-    '''id_term : ID'''
-    p[0] = [p[1], 'B'] # need help obtaining the type of the variable
+    def build(self, lexer, **kwargs):
+        global func_dir
+        func_dir = FunctionsDirectory()
 
-def p_seen_dec_func(p):
-    '''seen_dec_func :'''
-    # Al llegar a esta regla, significa que hemos visto el inicio de
-    # la declaración de una función.
-    # p[-1] es la producción en la que aparece el tipo de retorno
-    # p[-3] es la producción en la que aparece el nombre de la función
-    global last_vars
-    last_vars['scope'] = p[-3]
-    if not func_dir.add_function(last_vars['scope'], p[-1]):
-        print(f'Error: Re-declaration of function \'{p[-3]}\'.')
-        exit()
+        global last_vars
+        last_vars = {'scope': func_dir.GLOBAL_ENV, 'var_type': None}
 
-def p_seen_param(p):
-    '''seen_param :'''
-    # Al llegar a esta regla, significa que hemos visto
-    # la declaración de un parámetro.
-    # p[-1] es la producción en la que aparece nombre del parámetro
-    # p[-2] es la producción en la que aparece el tipo de dato
-    if not func_dir.add_param(last_vars['scope'], p[-1], p[-2]):
-        print(f'Error: Re-declaration of function parameter \'{p[-1]}\'.')
-        exit()
+        self.lexer = lexer
+        self.parser = yacc.yacc(module=self, **kwargs)
 
-def p_empty(p): # representa epsilon
-    '''empty : '''
-    pass
-
-def p_error(p):
-    print("Syntax error in input at line: ", p, p.lineno)
-    exit()
-
-# Por el momento esto es asi para poder "reiniciar" el directorio
-# y el scope a su estado inicial.
-def get_parser(withDebug=False):
-    global func_dir
-    func_dir = FunctionsDirectory()
-    
-    global last_vars
-    last_vars = {'scope': func_dir.GLOBAL_ENV, 'var_type': None}
-    
-    # "Reiniciar" el contador de lineas del lexer
-    lexer = LexerTudi()
-    lexer.build()
-    return yacc.yacc(debug=withDebug)
+    def parse(self, data):
+        return self.parser.parse(data)

--- a/parser_tudi.py
+++ b/parser_tudi.py
@@ -85,7 +85,7 @@ class ParserTudi(object):
     # Declaración de variables globales (opcional)
     def p_game_vars(self, p):
         '''game_vars : block_vars
-                    | empty'''
+                     | empty'''
 
     # Definición de funciones:
     # - Funciones definidas por el usuario (opcionales)
@@ -93,18 +93,18 @@ class ParserTudi(object):
     #   con código del usuario
     def p_game_funcs(self, p):
         '''game_funcs : declare_func game_funcs
-                    | game_start'''
+                      | game_start'''
 
     # Definición de función Start de TUDI (opcional)
     # Continúa con función Update de TUDI
     def p_game_start(self, p):
         '''game_start : func_start game_update
-                    | game_update'''
+                      | game_update'''
 
     # Definición de función Update de TUDI (opcional)
     def p_game_update(self, p):
         '''game_update : func_update
-                    | empty'''
+                       | empty'''
 
     # Bloque de declaración de variables
     def p_block_vars(self, p):
@@ -134,7 +134,7 @@ class ParserTudi(object):
     # Añadir una variable a la lista de variables
     def p_list_vars_prima(self, p):
         '''list_vars_prima : ',' ID list_vars_prima
-                        | empty'''
+                           | empty'''
         if len(p) > 2:
             p[0] = [Token(p[2], p.lineno(2))] + p[3]
         else:
@@ -162,18 +162,18 @@ class ParserTudi(object):
     # Lista de parámetros de una función
     def p_list_params(self, p):
         '''list_params : type ID seen_param list_params_prima
-                    | empty'''
+                       | empty'''
 
     # Añadir un parámetro a la lista de parámetros
     def p_list_params_prima(self, p):
         '''list_params_prima : ',' type ID seen_param list_params_prima
-                            | empty'''
+                             | empty'''
 
     # Tipo de dato posible como retorno de una función:
     # - Todos y VOID
     def p_func_type(self, p):
         '''func_type : type
-                    | VOID '''
+                     | VOID '''
         p[0] = p[1]
 
     # Bloque de código, puede incluir:
@@ -181,8 +181,8 @@ class ParserTudi(object):
     # - Estatutos
     def p_block_code(self, p):
         '''block_code : block_vars statement_prima
-                    | statement statement_prima
-                    | empty'''
+                      | statement statement_prima
+                      | empty'''
 
     # Un estatuto puede ser:
     # - Llamada a una función o métodos
@@ -191,17 +191,17 @@ class ParserTudi(object):
     # - Estatuto de retorno
     def p_statement(self, p):
         '''statement : call_func ';'
-                    | for_loop
-                    | while_loop
-                    | conditional
-                    | assignment ';'
-                    | return ';'
-                    | call_method ';' '''
+                     | for_loop
+                     | while_loop
+                     | conditional
+                     | assignment ';'
+                     | return ';'
+                     | call_method ';' '''
 
     # Añadir un estatuto más
     def p_statement_prima(self, p):
         '''statement_prima : statement statement_prima
-                        | empty'''
+                           | empty'''
 
     # Estatuto de retorno:
     # - Regresa una expresión
@@ -214,32 +214,32 @@ class ParserTudi(object):
     #         el argumento provisto. Retorna un string literal
     def p_io_func(self, p):
         '''io_func : PRINT '(' io_func_prima ')'
-                | READ  '(' io_func_prima ')' '''
+                   | READ  '(' io_func_prima ')' '''
 
     # El argumento posible de una función I/O
     def p_io_func_prima(self, p):
         '''io_func_prima : STRING_LITERAL
-                        | empty'''
+                         | empty'''
 
     # Funciones built-in de cast en TUDI:
     # - Para los tipos de datos: int, float y bool
     # - Reciben un string literal o un arreglo de chars
     def p_cast_func(self, p):
         '''cast_func : INT cast_func_prima
-                    | FLOAT cast_func_prima
-                    | BOOLEAN cast_func_prima'''
+                     | FLOAT cast_func_prima
+                     | BOOLEAN cast_func_prima'''
 
     # El argumento posible de una función de cast:
     # - String literal o arreglo de chars
     def p_cast_func_prima(self, p):
         '''cast_func_prima : '(' STRING_LITERAL ')'
-                        | '(' god_exp ')' '''
+                           | '(' god_exp ')' '''
 
     # Llamada a una función
     def p_call_func(self, p):
         '''call_func : ID '(' list_args ')'
-                    | io_func
-                    | cast_func'''
+                     | io_func
+                     | cast_func'''
         # Checa que exista una función definida por el usuario
         if len(p) > 2:
             if not self.func_dir.find_function(p[1]):
@@ -261,18 +261,18 @@ class ParserTudi(object):
     #                    define si el sprite puede ser manipulado por las teclas del usuario
     def p_call_method_prima(self, p):
         '''call_method_prima : SETPOSITION
-                            | TRANSLATE
-                            | SETCONTROLLABLE '''
+                             | TRANSLATE
+                             | SETCONTROLLABLE '''
 
     # Lista de argumentos (expresiones)
     def p_list_args(self, p):
         '''list_args : god_exp list_args_prima
-                    | empty'''
+                     | empty'''
 
     # Añadir un argumento a la lista de argumentos
     def p_list_args_prima(self, p):
         '''list_args_prima : ',' god_exp list_args_prima
-                        | empty'''
+                           | empty'''
 
     # Ciclo for loop (C/C++ style)
     def p_for_loop(self, p):
@@ -293,8 +293,8 @@ class ParserTudi(object):
     # Else-If / Else condicional (C/C++ style)
     def p_conditional_prima(self, p):
         '''conditional_prima : ELSE conditional
-                            | ELSE '{' block_code '}'
-                            | empty'''
+                             | ELSE '{' block_code '}'
+                             | empty'''
 
     # Asignación de una expresión a una variables:
     # - Se debe verificar que los tipos de datos coincidan
@@ -318,8 +318,8 @@ class ParserTudi(object):
     # aceptan int literals para la definición del tamaño
     def p_type_dims(self, p):
         '''type_dims : '[' INT_LITERAL ']'
-                    | '[' INT_LITERAL ',' INT_LITERAL ']'
-                    | empty'''
+                     | '[' INT_LITERAL ',' INT_LITERAL ']'
+                     | empty'''
         if len(p) == 6:
             p[0] = 'arr2d'
         elif len(p) == 4:
@@ -336,7 +336,7 @@ class ParserTudi(object):
     # Operadores lógicos
     def p_god_exp_prima(self, p):
         '''god_exp_prima : LOGIC_OPS add_op god_exp
-                        | empty'''
+                         | empty'''
 
     def p_super_exp(self, p):
         '''super_exp : exp super_exp_neuro_1 super_exp_prima'''
@@ -348,7 +348,7 @@ class ParserTudi(object):
     # Operadores relacionales
     def p_super_exp_prima(self, p):
         '''super_exp_prima : REL_OPS add_op exp
-                        | empty'''
+                           | empty'''
 
     def p_exp(self, p):
         '''exp : term exp_neuro_1 exp_prima'''
@@ -360,8 +360,8 @@ class ParserTudi(object):
     # Operadores suma y resta
     def p_exp_prima(self, p):
         '''exp_prima : '+' add_op exp
-                    | '-' add_op exp
-                    | empty'''
+                     | '-' add_op exp
+                     | empty'''
 
     def p_term(self, p):
         '''term : fact term_neuro_1 term_prima'''
@@ -373,8 +373,8 @@ class ParserTudi(object):
     # Operadores de multiplación y división
     def p_term_prima(self, p):
         '''term_prima : '/' add_op term
-                    | '*' add_op term
-                    | empty'''
+                      | '*' add_op term
+                      | empty'''
 
     # Factores de una expresión:
     # - Operadores de agrupacion (paréntesis)
@@ -393,10 +393,10 @@ class ParserTudi(object):
     def p_fact_constants(self, p):
         '''
         fact_constants : id_exp
-                        | int
-                        | float
-                        | bool
-                        | call_func
+                       | int
+                       | float
+                       | bool
+                       | call_func
         '''
         p[0] = p[1]
 
@@ -432,8 +432,8 @@ class ParserTudi(object):
     # - Elemento de un arreglo de 1 o 2 dimensiones
     def p_id_exp(self, p):
         '''id_exp : id_term
-                | id_term '[' god_exp ']'
-                | id_term '[' god_exp ',' god_exp ']' '''
+                  | id_term '[' god_exp ']'
+                  | id_term '[' god_exp ',' god_exp ']' '''
         if len(p) == 6:
             p[0] = Token([p[1][0], p[3], p[5]], p.lineno(1))
         elif len(p) == 4:

--- a/parser_tudi.py
+++ b/parser_tudi.py
@@ -124,7 +124,7 @@ class ParserTudi(object):
         for var_id in p[2]:
             if not self.func_dir.add_variable(self.last_vars['scope'], var_id.value, self.last_vars['var_type']):
                 print(f'Error: Re-declaration of variable \'{var_id.value}\' at line: {var_id.lineno}')
-                exit()
+                raise Exception(f'Error: Re-declaration of variable \'{var_id.value}\' at line: {var_id.lineno}')
 
     # Lista de variables
     def p_list_vars(self, p):
@@ -244,7 +244,7 @@ class ParserTudi(object):
         if len(p) > 2:
             if not self.func_dir.find_function(p[1]):
                 print(f'Error: Function \'{p[1]}\' at line {p.lineno(1)} was not declared.')
-                exit()
+                raise Exception(f'Error: Function \'{p[1]}\' at line {p.lineno(1)} was not declared.')
         p[0] = [0, 'B', p[0]] # Dummy value in the meantime, need help obtaining data type
 
     # Llamada a un método, requisitos:
@@ -444,7 +444,7 @@ class ParserTudi(object):
         # Checa si la variable fue declarada con anterioridad
         if not self.func_dir.find_variable(self.last_vars['scope'], p[1][0]):
             print(f'Error: Variable \'{p[1]}\' at line {p.lineno(1)} was not declared.')
-            exit()
+            raise Exception(f'Error: Variable \'{p[1]}\' at line {p.lineno(1)} was not declared.')
         p[0] = [0, p[1][1], p[0]]
 
     # Identificador de la variable
@@ -461,7 +461,7 @@ class ParserTudi(object):
         self.last_vars['scope'] = p[-3]
         if not self.func_dir.add_function(self.last_vars['scope'], p[-1]):
             print(f'Error: Re-declaration of function \'{p[-3]}\'.')
-            exit()
+            raise Exception(f'Error: Re-declaration of function \'{p[-3]}\'.')
 
     def p_seen_param(self, p):
         '''seen_param :'''
@@ -471,7 +471,7 @@ class ParserTudi(object):
         # p[-2] es la producción en la que aparece el tipo de dato
         if not self.func_dir.add_param(self.last_vars['scope'], p[-1], p[-2]):
             print(f'Error: Re-declaration of function parameter \'{p[-1]}\'.')
-            exit()
+            raise Exception(f'Error: Re-declaration of function parameter \'{p[-1]}\'.')
 
     # Representa Epsilon
     def p_empty(self, p):
@@ -481,7 +481,7 @@ class ParserTudi(object):
     # Error handling
     def p_error(self, p):
         print("Syntax error in input at line: ", p, p.lineno)
-        exit()
+        raise Exception("Syntax error in input at line: ", p, p.lineno)
 
     # Build parser with initial state
     def build(self, lexer, **kwargs):

--- a/quadruples.py
+++ b/quadruples.py
@@ -1,0 +1,80 @@
+from collections import deque
+
+type_dict = {'int': 'I', 'float': 'F', 'char': 'C', 'bool': 'B', 'arr1d': 'A'}
+
+class QuadrupleGenerator():
+    def __init__(self):
+        # Cuadruplos y contador
+        self.quadruples = []
+        self.count_q = 1
+        
+        # Variables temporales
+        self.temp_vars = 0
+        
+        # Pilas
+        self.operator_stack = deque() 
+        self.operand_stack = deque() 
+        self.type_stack = deque() 
+        self.goto_stack = deque()
+
+    # Añade una operador a la pila correspondiente
+    def add_operator(self, operator):
+        self.operator_stack.append(operator)
+
+    # Regresa y elimina el operador más reciente en la pila correspondiente
+    def pop_operator(self):
+        return self.operator_stack.pop()
+
+    # Añade un tipo y operando a las pila correspondientes
+    def add_operand(self, type_t, operand):
+        self.type_stack.append(type_t)
+        self.operand_stack.append(operand)
+
+    # Regresa y elimina el tipo y operando más recientes de las pilas correspondientes
+    def pop_operand(self):
+        return self.type_stack.pop(), self.operand_stack.pop()
+
+    def get_next_temp(self):
+        # On the meantime returns string, wait for memory implementation
+        self.temp_vars += 1
+        return 'T' + str(self.temp_vars)
+
+    # Utiliza un cubo semántico para validar que una expresión es correcta
+    def check_stack_operand(self, arr_operators, sem_cube):
+        if len(self.operator_stack) > 0 and (self.operator_stack[-1] in arr_operators):
+            right_oper = self.operand_stack.pop()
+            right_type = self.type_stack.pop()
+            
+            left_oper = self.operand_stack.pop()
+            left_type = self.type_stack.pop()
+
+            operator = self.operator_stack.pop()
+
+            result_t = sem_cube.validate_expression(left_type, right_type, operator)
+
+            if result_t == "ERROR: Not valid operation":
+                raise Exception("TYPE MISMATCH")
+
+            t = self.get_next_temp()
+            
+            self.quadruples.append(Quadruple(self.count_q, operator, left_oper, right_oper, t))
+            self.count_q += 1
+            
+            result_t = type_dict[result_t]
+            self.operand_stack.append(t)
+            self.type_stack.append(result_t)
+
+    def print_quadruples(self):
+        for i in self.quadruples:
+            print(i)
+
+class Quadruple():
+    def __init__(self, id, operator, left_operand, right_operand, temp):
+        self.id = id
+        self.operator = operator
+        self.left_operand = left_operand
+        self.right_operand = right_operand
+        self.temp = temp
+
+    def __str__(self):
+        return f'id: {self.id}, operator: {self.operator}, left_operand: {self.left_operand}, right_operand: {self.right_operand}, temp: {self.temp}\n'

--- a/test.py
+++ b/test.py
@@ -1,15 +1,17 @@
 import unittest
 import os
 
-from parser_tudi import get_parser
+from lexer import LexerTudi
+from parser_tudi import ParserTudi
 
 class TestTUDI(unittest.TestCase):
     def setUp(self):
         self.folder = "test_cases"
-        self.parser = get_parser()
+        self.lexer = LexerTudi()
+        self.lexer.build()
 
-    def tearDown(self):
-        self.parser.restart()
+        self.parser = ParserTudi()
+        self.parser.build(self.lexer)
 
     def test_tudi(self):
         f = open(os.path.join(self.folder, "test.tudi"), 'r')


### PR DESCRIPTION
Motivación principal de este PR es para que los resultados de los tests estén aislados el uno del otro. (Ejemplo: que la lista de cuadruplos no acumulen todos los cuadruplos)

**TODO**: Fix expression quadruples